### PR TITLE
Add new config options to disable mushrooms and to make the screen turn red as you starve

### DIFF
--- a/.github/workflows/windows_linux.yml
+++ b/.github/workflows/windows_linux.yml
@@ -67,6 +67,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./scripts/hetuwScripts/windows/bin/OneLifeApp_H_windows.exe
+          asset_path: ./scripts/hetuwScripts/bin/OneLifeApp_H_windows.exe
           asset_name: OneLifeApp_H_windows.exe
           asset_content_type: application/zip

--- a/build/source/runToBuild
+++ b/build/source/runToBuild
@@ -47,7 +47,12 @@ ls
 
 
 echo "Copying items from build into directories"
-cp OneLife/gameSource/OneLife ./OneLifeApp
+if [ "$1" = "5" ] # windows
+then
+    cp OneLife/gameSource/OneLife.exe ./OneLifeApp.exe
+else
+    cp OneLife/gameSource/OneLife ./OneLifeApp
+fi
 cp OneLife/documentation/Readme.txt .
 cp OneLife/no_copyright.txt .
 cp OneLife/gameSource/graphics/* ./graphics

--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -17410,7 +17410,8 @@ void LivingLifePage::step() {
                                 otherSoundPlayed = true;
                                 }
                             if( strstr( ateObj->description, "remapStart" )
-                                != NULL ) {
+                                != NULL &&
+                                HetuwMod::bRemapStart ) {
                                 
                                 if( mRemapPeak == 0 ) {
                                     // reseed

--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -172,6 +172,7 @@ static char vogPickerOn = false;
 bool LivingLifePage::hetuwIsVogMode() { return vogMode; }
 doublePair LivingLifePage::hetuwGetVogPos() { return vogPos; }
     
+int LivingLifePage::hetuwGetYumBonus() { return mYumBonus; }
 
 extern float musicLoudness;
 

--- a/gameSource/LivingLifePage.h
+++ b/gameSource/LivingLifePage.h
@@ -572,6 +572,7 @@ class LivingLifePage : public GamePage, public ActionListener {
 		void hetuwSetTakingPhoto(bool takingPhoto);
 		bool hetuwIsVogMode();
 		doublePair hetuwGetVogPos();
+        int hetuwGetYumBonus();
 		char getTransHintable( TransRecord *inTrans ); // hetuw mod - changed from static and made visible to public
 		
         virtual void actionPerformed( GUIComponent *inTarget );

--- a/gameSource/hetuwmod.cpp
+++ b/gameSource/hetuwmod.cpp
@@ -5048,7 +5048,7 @@ void HetuwMod::drawHelp() {
 }
 
 void HetuwMod::drawHungerWarning() {
-	if ( ourLiveObject->foodStore + livingLifePage->mYumBonus <= 2 && ourLiveObject->maxFoodCapacity > 8) {
+	if ( ourLiveObject->foodStore + livingLifePage->hetuwGetYumBonus() <= 2 && ourLiveObject->maxFoodCapacity > 8) {
 		float alpha = ( 1 - (ourLiveObject->foodStore / 8.0) ) * 0.3;
 		doublePair startPos = livingLifePage->hetuwGetLastScreenViewCenter();
 		setDrawColor( 1, 0, 0, alpha );

--- a/gameSource/hetuwmod.cpp
+++ b/gameSource/hetuwmod.cpp
@@ -1127,7 +1127,7 @@ void HetuwMod::initSettings() {
 	ofs << endl;
 	ofs << "chat_delay = " << to_string((int)(sayDelay*10)) << " // wait atleast X time before sending the next text (10 = 1 second) - set it to 0 to deactivate it" << endl;
 	ofs << endl;
-	ofs << "remap_start_enabled = " << (char)(bRemapStart+48) << endl;
+	ofs << "remap_start_enabled = " << (char)(bRemapStart+48) << " // enable mushroom effect" << endl;
 
 	ofs.close();
 }

--- a/gameSource/hetuwmod.cpp
+++ b/gameSource/hetuwmod.cpp
@@ -250,6 +250,8 @@ int HetuwMod::serverPort = 0;
 
 bool HetuwMod::addBabyCoordsToList = false;
 
+bool HetuwMod::bRemapStart = true;
+
 std::vector<HetuwMod::HttpRequest*> HetuwMod::httpRequests;
 
 bool HetuwMod::connectedToMainServer = false;
@@ -976,9 +978,12 @@ bool HetuwMod::setSetting( const char* name, const char* value ) {
 		bWriteLogs = bool(value[0]-48);
 		return true;
 	}
-
 	if (strstr(name, "chat_delay")) {
 		sayDelay = stoi(value)/10.0f;
+		return true;
+	}
+	if (strstr(name, "remap_start_enabled")) {
+		bRemapStart = bool(value[0]-'0');
 		return true;
 	}
 
@@ -1116,6 +1121,8 @@ void HetuwMod::initSettings() {
 	ofs << "hetuw_log = " << (char)(bWriteLogs+48) << " // will create a log file '" << hetuwLogFileName << "' which resets at the beginning of each life - logs different events" << endl;
 	ofs << endl;
 	ofs << "chat_delay = " << to_string((int)(sayDelay*10)) << " // wait atleast X time before sending the next text (10 = 1 second) - set it to 0 to deactivate it" << endl;
+	ofs << endl;
+	ofs << "remap_start_enabled = " << (char)(bRemapStart+48) << endl;
 
 	ofs.close();
 }

--- a/gameSource/hetuwmod.cpp
+++ b/gameSource/hetuwmod.cpp
@@ -1186,7 +1186,7 @@ void HetuwMod::initOnBirth() { // will be called from LivingLifePage.cpp
 	writeLineToLogs("my_id", to_string(ourLiveObject->id));
 	writeLineToLogs("my_age", to_string((int)livingLifePage->hetuwGetAge(ourLiveObject)));
 
-	Phex::onBirth()
+	Phex::onBirth();
 }
 
 void HetuwMod::initOnServerJoin() { // will be called from LivingLifePage.cpp and hetuwmod.cpp

--- a/gameSource/hetuwmod.cpp
+++ b/gameSource/hetuwmod.cpp
@@ -251,6 +251,7 @@ int HetuwMod::serverPort = 0;
 bool HetuwMod::addBabyCoordsToList = false;
 
 bool HetuwMod::bRemapStart = true;
+bool HetuwMod::bDrawHungerWarning = false;
 
 std::vector<HetuwMod::HttpRequest*> HetuwMod::httpRequests;
 
@@ -990,6 +991,10 @@ bool HetuwMod::setSetting( const char* name, const char* value ) {
 		bRemapStart = bool(value[0]-'0');
 		return true;
 	}
+	if (strstr(name, "draw_hunger_warning")) {
+		bDrawHungerWarning = bool(value[0]-'0');
+		return true;
+	}
 
 	return false;
 }
@@ -1128,6 +1133,7 @@ void HetuwMod::initSettings() {
 	ofs << "chat_delay = " << to_string((int)(sayDelay*10)) << " // wait atleast X time before sending the next text (10 = 1 second) - set it to 0 to deactivate it" << endl;
 	ofs << endl;
 	ofs << "remap_start_enabled = " << (char)(bRemapStart+48) << " // enable mushroom effect" << endl;
+	ofs << "draw_hunger_warning = " << (char)(bDrawHungerWarning+48) << endl;
 
 	ofs.close();
 }
@@ -2112,6 +2118,7 @@ void HetuwMod::livingLifeDraw() {
 	//drawRect( debugRecPos2, 10, 10 );
 
 	if (bDrawBiomeInfo) drawBiomeIDs();
+	if (bDrawHungerWarning) drawHungerWarning();
 }
 
 void HetuwMod::drawCoordsHelpA() {
@@ -5037,5 +5044,14 @@ void HetuwMod::drawHelp() {
 		drawPos.y += viewHeight/2 - 30*guiScale;
 		sprintf(str, "MAP RUNNING SINCE: %s", getArcTimeStr().c_str());
 		livingLifePage->hetuwDrawScaledHandwritingFont( str, drawPos, guiScale );
+	}
+}
+
+void HetuwMod::drawHungerWarning() {
+	if ( ourLiveObject->foodStore + livingLifePage->mYumBonus <= 2 && ourLiveObject->maxFoodCapacity > 8) {
+		float alpha = ( 1 - (ourLiveObject->foodStore / 8.0) ) * 0.3;
+		doublePair startPos = livingLifePage->hetuwGetLastScreenViewCenter();
+		setDrawColor( 1, 0, 0, alpha );
+		drawRect( startPos, viewWidth * guiScale, viewHeight * guiScale );
 	}
 }

--- a/gameSource/hetuwmod.cpp
+++ b/gameSource/hetuwmod.cpp
@@ -1185,6 +1185,8 @@ void HetuwMod::initOnBirth() { // will be called from LivingLifePage.cpp
 	writeLineToLogs("my_birth", getTimeStamp());
 	writeLineToLogs("my_id", to_string(ourLiveObject->id));
 	writeLineToLogs("my_age", to_string((int)livingLifePage->hetuwGetAge(ourLiveObject)));
+
+	Phex::onBirth()
 }
 
 void HetuwMod::initOnServerJoin() { // will be called from LivingLifePage.cpp and hetuwmod.cpp

--- a/gameSource/hetuwmod.cpp
+++ b/gameSource/hetuwmod.cpp
@@ -909,6 +909,10 @@ bool HetuwMod::setSetting( const char* name, const char* value ) {
 		Phex::forceChannel = string(value);
 		return true;
 	}
+	if (strstr(name, "phex_send_fake_life")) {
+		Phex::bSendFakeLife = bool(value[0]-'0');
+		return true;
+	}
 	if (strstr(name, "send_keyevents")) {
 		sendKeyEvents = bool(value[0]-48);
 		return true;
@@ -1094,6 +1098,7 @@ void HetuwMod::initSettings() {
 	ofs << "phex_port = " << phexPort << endl;
 	ofs << "phex_coords = " << (char)(Phex::allowServerCoords+48) << endl;
 	if (Phex::forceChannel.length() > 1) ofs << "phex_channel = " << Phex::forceChannel << endl;
+	if (Phex::bSendFakeLife) ofs << "phex_send_fake_life = " << (char)(Phex::bSendFakeLife+48) << endl;
 	if (debugPhex) ofs << "phex_debug = " << (char)(debugPhex+48) << endl;
 	if (sendKeyEvents) {
 		ofs << endl;

--- a/gameSource/hetuwmod.h
+++ b/gameSource/hetuwmod.h
@@ -582,6 +582,7 @@ public:
 	static bool bHidePlayers;
 	static char ourGender;
 	static bool bRemapStart;
+	static bool bDrawHungerWarning;
 
 	static bool bFoundFamilyName;
 	static std::vector<FamilyInRange*> familiesInRange;

--- a/gameSource/hetuwmod.h
+++ b/gameSource/hetuwmod.h
@@ -799,6 +799,8 @@ private:
 	static void drawBiomeIDs();
 
 	static void initCustomFont();
+
+	static void drawHungerWarning();
 };
 
 

--- a/gameSource/hetuwmod.h
+++ b/gameSource/hetuwmod.h
@@ -581,6 +581,7 @@ public:
 	static bool bxRay;
 	static bool bHidePlayers;
 	static char ourGender;
+	static bool bRemapStart;
 
 	static bool bFoundFamilyName;
 	static std::vector<FamilyInRange*> familiesInRange;

--- a/gameSource/phex.cpp
+++ b/gameSource/phex.cpp
@@ -88,6 +88,8 @@ bool Phex::allowServerCoords = true;
 
 std::string Phex::forceChannel = "";
 
+bool Phex::bSendFakeLife = false;
+
 bool Phex::sendBiomeDataActive = false;
 char Phex::biomeChunksSent[biomeChunksSentSize][biomeChunksSentSize];
 HetuwMod::IntervalTimed Phex::intervalSendBiomeData = HetuwMod::IntervalTimed(1.0);
@@ -938,13 +940,17 @@ void Phex::joinChannel(std::string inChannelName) {
 	tcp.send("JOIN "+channelName);
 	mainChatWindow.clear();
 	tcp.send("GETLAST "+channelName+" 30");
-	sendServerLife();
+	if (bSendFakeLife) {
+		sendServerLife(1);
+	} else {
+		sendServerLife(HetuwMod::ourLiveObject->id);
+	}
 }
 
-void Phex::sendServerLife() {
+void Phex::sendServerLife(int life) {
 	std::string msg = "SERVER_LIFE ";
 	msg += std::string(HetuwMod::serverIP)+" ";
-	msg += std::to_string(HetuwMod::ourLiveObject->id);
+	msg += std::to_string(life);
 	tcp.send(msg);
 }
 

--- a/gameSource/phex.cpp
+++ b/gameSource/phex.cpp
@@ -506,6 +506,9 @@ void Phex::initChatCommands() {
 	chatCommands["LIST"].func = chatCmdLIST;
 	chatCommands["LIST"].minWords = 1;
 	chatCommands["LIST"].helpStr = "Lists all online players";
+	chatCommands["LIFE"].func = chatCmdLIFE;
+	chatCommands["LIFE"].minWords = 1;
+	chatCommands["LIFE"].helpStr = "Sends your real life ID to server";
 	chatCommands["TEST"].func = chatCmdTEST;
 	chatCommands["TEST"].minWords = 1;
 	chatCommands["TEST"].helpStr = "For testing - dont use";
@@ -514,7 +517,7 @@ void Phex::initChatCommands() {
 void Phex::chatCmdHELP(std::vector<std::string> input) {
 	for (std::pair<std::string, ChatCommand> element : chatCommands) {
 		strToLower(element.first);
-		if (strEquals(element.first, "test")) continue;
+		if (strEquals(element.first, "test") || (strEquals(element.first, "life") && !bSendFakeLife)) continue;
 		addCmdMessageToChatWindow(strCmdChar+element.first);
 		addCmdMessageToChatWindow(element.second.helpStr);
 	}
@@ -543,6 +546,12 @@ void Phex::chatCmdLIST(std::vector<std::string> input) {
 		}
 
 		addCmdMessageToChatWindow(str);
+	}
+}
+
+void Phex::chatCmdLIFE(std::vector<std::string> input) {
+	if (bSendFakeLife) {
+		sendServerLife(HetuwMod::ourLiveObject->id);
 	}
 }
 

--- a/gameSource/phex.cpp
+++ b/gameSource/phex.cpp
@@ -1250,11 +1250,17 @@ void Phex::onRingApoc(int x, int y) {
 }
 
 void Phex::onBirth() {
+	if (tcp.status == TCPConnection::ONLINE) {
+		if (forceChannel.length() > 1) joinChannel(forceChannel);
+		else joinChannel(string(HetuwMod::serverIP));
+	}
+	/*
 	for (int x=0; x<biomeChunksSentSize; x++) {
 		for (int y=0; y<biomeChunksSentSize; y++) {
 			biomeChunksSent[x][y] = 0;
 		}
 	}
+	*/
 }
 
 void Phex::sendBiomeChunk(int chunkX, int chunkY) {

--- a/gameSource/phex.h
+++ b/gameSource/phex.h
@@ -293,6 +293,8 @@ public:
 
 	static std::string forceChannel;
 
+	static bool bSendFakeLife;
+
 	static constexpr char hexDigits[16] = { '0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f' };
 
 	static void init();

--- a/gameSource/phex.h
+++ b/gameSource/phex.h
@@ -354,7 +354,7 @@ public:
 
 	static void sendFirstMessage();
 	static void joinChannel(std::string inChannelName);
-	static void sendServerLife();
+	static void sendServerLife(int life);
 
 	static void setInputRecDrawData();
 	static void drawInputRec();

--- a/gameSource/phex.h
+++ b/gameSource/phex.h
@@ -326,6 +326,7 @@ public:
 	static void chatCmdHELP(std::vector<std::string> input);
 	static void chatCmdNAME(std::vector<std::string> input);
 	static void chatCmdLIST(std::vector<std::string> input);
+	static void chatCmdLIFE(std::vector<std::string> input);
 	static void chatCmdTEST(std::vector<std::string> input);
 
 	static void setArray(float arrDst[], const float arrSrc[], int size);


### PR DESCRIPTION
- Effects stemming from remapStart (Psilocybe Mushrooms) can now be disabled with the config option `remap_start_enabled`
- You can now enable a red overlay on your screen when starving with the config option `draw_hunger_warning`
- Fixed a bug causing Phex channels to not properly switch when joining a different game server