### PR TITLE
Reconfigure build scripts to use environment variables for repository names

### DIFF
--- a/.github/workflows/windows_linux.yml
+++ b/.github/workflows/windows_linux.yml
@@ -1,10 +1,12 @@
 name: CI
 
 on: 
-  #schedule:
-  #  - cron: '0 10 * * * '
-  #  - cron: '0 * * * * '
-  push:
+  workflow_dispatch:
+    inputs:
+      release_name:
+        description: Release Name
+        required: true
+        type: string
 jobs:
   build:
     strategy:
@@ -47,8 +49,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: OneLife_v372
-          release_name: OneLife_v372
+          tag_name: ${{ inputs.release_name }}
+          release_name: ${{ inputs.release_name }}
           body: |
             In order to install, you already need to have the normal version of the game.
             Then download the binary "OneLifeApp_H_windows" and place it inside your One Hour One Life folder.

--- a/.github/workflows/windows_linux.yml
+++ b/.github/workflows/windows_linux.yml
@@ -12,6 +12,7 @@ jobs:
         os: [ubuntu-latest]
       fail-fast: true
     runs-on: ${{ matrix.os }}
+    environment: master
     steps:
       - uses: actions/checkout@v2
       - name: packages
@@ -24,6 +25,11 @@ jobs:
           ./hetuwPullLatest.sh linux 1 
           ./hetuwPullLatest.sh windows 3 
           ./hetuwCompileAll.sh
+        env:
+          ONELIFE_BRANCH: ${{ vars.ONELIFE_BRANCH }}
+          ONELIFE_REPO: ${{ vars.ONELIFE_REPO }}
+          MINORGEMS_BRANCH: ${{ vars.MINORGEMS_BRANCH }}
+          MINORGEMS_REPO: ${{ vars.MINORGEMS_REPO }}
       - name: test dir
         run: |
           cd scripts/hetuwScripts

--- a/scripts/hetuwScripts/hetuwPullLatest.sh
+++ b/scripts/hetuwScripts/hetuwPullLatest.sh
@@ -76,15 +76,19 @@ then
 	fi
 fi
 
+ONELIFE_BRANCH=${ONELIFE_BRANCH:-master}
+ONELIFE_REPO=${ONELIFE_REPO:-https://github.com/hetuw/OneLife.git}
+MINORGEMS_BRANCH=${MINORGEMS_BRANCH:-master}
+MINORGEMS_REPO=${MINORGEMS_REPO:-https://github.com/hetuw/minorGems.git}
 
 if [ ! -e minorGems ]
 then
-	git clone https://github.com/selb/YumLifeMinorGems minorGems
+	git clone -b $MINORGEMS_BRANCH $MINORGEMS_REPO minorGems
 fi
 
 if [ ! -e OneLife ]
 then
-	git clone https://github.com/selb/YumLife OneLife
+	git clone -b $ONELIFE_BRANCH $ONELIFE_REPO OneLife
 fi
 
 

--- a/scripts/hetuwScripts/hetuwPushToHetuw.sh
+++ b/scripts/hetuwScripts/hetuwPushToHetuw.sh
@@ -5,12 +5,12 @@ cd OneLife
 echo 
 echo "PUSH OneLife"
 echo
-git push https://github.com/selb/YumLife
+git push https://github.com/hetuw/OneLife
 cd ..
 cd minorGems
 echo 
 echo "PUSH minorGems"
 echo
-git push https://github.com/selb/YumLifeMinorGems
+git push https://github.com/hetuw/minorGems
 cd ..
 cd ..


### PR DESCRIPTION
Please ensure you set the following environment variables properly before building:
- ONELIFE_BRANCH
- ONELIFE_REPO
- MINORGEMS_BRANCH
- MINORGEMS_REPO

Otherwise, they will default to the original Hetuw repository.