### PR TITLE
Fix bugs with workflow, dangerous animals, and key handlers

### DIFF
--- a/.github/workflows/windows_linux.yml
+++ b/.github/workflows/windows_linux.yml
@@ -27,7 +27,7 @@ jobs:
           ./hetuwPullLatest.sh windows 3 
           ./hetuwCompileAll.sh
         env:
-          ONELIFE_BRANCH: ${{ vars.ONELIFE_BRANCH }}
+          ONELIFE_BRANCH: ${{ github.ref_name }}
           ONELIFE_REPO: ${{ vars.ONELIFE_REPO }}
           MINORGEMS_BRANCH: ${{ vars.MINORGEMS_BRANCH }}
           MINORGEMS_REPO: ${{ vars.MINORGEMS_REPO }}

--- a/.github/workflows/windows_linux.yml
+++ b/.github/workflows/windows_linux.yml
@@ -17,11 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: packages
-        run: sudo apt-get install git g++ imagemagick xclip libsdl1.2-dev libglu1-mesa-dev libgl1-mesa-dev mingw-w64
+        run: |
+          sudo apt-get update
+          sudo apt-get install git g++ make imagemagick xclip libsdl1.2-dev libglu1-mesa-dev libgl1-mesa-dev mingw-w64
       - name: scripts
         run: |
           cd scripts/hetuwScripts
-          sudo apt-get install git g++ make imagemagick xclip libsdl1.2-dev libglu1-mesa-dev libgl1-mesa-dev 
           chmod +x hetuwPullLatest.sh 
           ./hetuwPullLatest.sh linux 1 
           ./hetuwPullLatest.sh windows 3 

--- a/.github/workflows/windows_linux.yml
+++ b/.github/workflows/windows_linux.yml
@@ -14,7 +14,6 @@ jobs:
         os: [ubuntu-latest]
       fail-fast: true
     runs-on: ${{ matrix.os }}
-    environment: master
     steps:
       - uses: actions/checkout@v2
       - name: packages

--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -25966,7 +25966,7 @@ void LivingLifePage::keyDown( unsigned char inASCII ) {
                 setSignal( "twinCancel" );
                 }
             else if( ! mSayField.isFocused() ) {
-                mXKeyDown = false; // hetuw mod disable click through player function - confuses people
+                mXKeyDown = true;
                 }
             break;
         /*

--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -25866,7 +25866,7 @@ void LivingLifePage::keyDown( unsigned char inASCII ) {
 	}
 	if (!vogMode) {
 		if (Phex::hasFocus && mSayField.isFocused()) mSayField.unfocusAll();
-		if (HetuwMod::livingLifeKeyDown(inASCII)) return;
+		if (HetuwMod::livingLifeKeyDown(inASCII) && inASCII != 'z') return;
 	}
 
     switch( inASCII ) {

--- a/gameSource/hetuwmod.cpp
+++ b/gameSource/hetuwmod.cpp
@@ -674,6 +674,7 @@ bool HetuwMod::strContainsDangerousAnimal(const char* str) {
 	if (strstr( str, "Skinned Wolf") != NULL) return false;
 	if (strstr( str, "Skinless Wolf") != NULL) return false;
 	if (strstr( str, "Dead Wolf") != NULL) return false;
+	if (strstr( str, "Buried Wolf") != NULL) return false;
 	if (strstr( str, "Shot Domestic Boar with Piglet") != NULL) return false;
 	if (strstr( str, "Shot Wild Boar with Piglet") != NULL) return false;
 	if (strstr( str, "Dead Grizzly Bear") != NULL) return false;
@@ -710,6 +711,7 @@ void HetuwMod::initDangerousAnimals() {
 	int a = -1;
 
 	a++; dangerousAnimals[a] = 2156; // Mosquito swarm
+	a++; dangerousAnimals[a] = 2157; // Mosquito swarm - just bit
 
 	a++; dangerousAnimals[a] = 764; // Rattle Snake
 	a++; dangerousAnimals[a] = 1385; // Attacking Rattle Snake
@@ -3832,15 +3834,23 @@ bool HetuwMod::tileHasNoDangerousAnimals(int x, int y) {
 	int objId = livingLifePage->hetuwGetObjId( x, y);
 	if (objId <= 0) return true;
 	if (ourLiveObject->holdingID > 0 && getObject(ourLiveObject->holdingID)->rideable) {
-		if (ourLiveObject->holdingID == 2395 || // Crude Car with Empty Tank
-			ourLiveObject->holdingID == 2400 || // Crude Car with Empty Tank#driven
-			ourLiveObject->holdingID == 2396 || // Running Crude Car
-			ourLiveObject->holdingID == 2394) { // Unpowered Crude Car
+		if (ourLiveObject->holdingID == 2396 || // Running Crude Car
+			ourLiveObject->holdingID == 4655 || // Deliver Truck - +slotsInvis driving
+			ourLiveObject->holdingID == 4660 || // Red Sports Car $30 - driving +varNumeral
+			ourLiveObject->holdingID == 4681 || // Blue Sports Car $30 - driving +varNumeral
+			ourLiveObject->holdingID == 4690 || // Green Sports Car $30 - driving +varNumeral
+			ourLiveObject->holdingID == 4699 || // Yellow Sports Car $30 - driving +varNumeral
+			ourLiveObject->holdingID == 4708 || // Black Sports Car $30 - driving +varNumeral
+			ourLiveObject->holdingID == 4719) { // White Sports Car $30 - driving +varNumeral
 				return true; // no dangerous animals for cars
 		}
 		// check dangerous animals for horses
 		if (objId == 764) return false; // Rattle Snake	
 		if (objId == 1385) return false; // Attacking Rattle Snake
+		if (objId == 631) return false; // Hungry Grizzly Bear
+		if (objId == 628) return false; // Grizzly Bear
+		if (objId == 645) return false; // Fed Grizzly Bear
+		if (objId == 4762) return false; // Sleepy Grizzly Bear
 	} else { // moving by walking / not riding
 		if (objId < maxObjects && isDangerousAnimal[objId]) return false;
 	}


### PR DESCRIPTION
- Set `ONELIFE_REPO` environment variable to use the current branch in the workflow automatically
- Run `sudo apt-get update` to ensure package installation doesn't fail during the workflow
- Buried Wolves no longer appear to be dangerous
- Mosquitos will always appear to be dangerous
- Delivery trucks and sports cars can now enter dangerous tiles
- Horses will not be able to enter tiles containing grizzly bears
- The Z key should now properly cycle to previous crafting hints when used with TAB
- The X key will now properly allow clicking through players if it is not bound to anything in `hetuw.cfg`