### PR TITLE
Add encoding and decoding feature for numbers in speech and other small improvements

### DIFF
--- a/gameSource/ExistingAccountPage.cpp
+++ b/gameSource/ExistingAccountPage.cpp
@@ -309,11 +309,10 @@ void ExistingAccountPage::makeActive( char inFresh ) {
         mReviewButton.setLabelText( translate( "postReviewButton" ) );
         }
 
+    // YumLife: always show review button
+    mReviewButton.setVisible( true );
 
     if( SettingsManager::getIntSetting( "useSteamUpdate", 0 ) ) {
-        // no review button on Steam
-        mReviewButton.setVisible( false );
-        
         if( ! loginEditOverride ) {
             mEmailField.setVisible( false );
             mKeyField.setVisible( false );
@@ -343,7 +342,6 @@ void ExistingAccountPage::makeActive( char inFresh ) {
         }
     else {
         mHideAccount = false;
-        mReviewButton.setVisible( true );
         mViewAccountButton.setVisible( false );
         }
     }

--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -19891,6 +19891,7 @@ void LivingLifePage::step() {
                                 
                                 existing->currentSpeech = 
                                     stringDuplicate( &( firstSpace[1] ) );
+                                HetuwMod::decodeDigits( existing->currentSpeech, existing->currentSpeech );  // YumLife mod
                                 
 
                                 double curTime = game_getCurrentTime();

--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -14844,7 +14844,14 @@ void LivingLifePage::step() {
                     
                     if( d > 32 ) {
                         addAncientHomeLocation( posX, posY );
-						HetuwMod::addHomeLocation( posX, posY, (monumentID == HetuwMod::OBJID_EndTowerSound) ? HetuwMod::hpt_apoc : HetuwMod::hpt_bell );
+                        // YumLife mod
+                        HetuwMod::homePosType hpt = HetuwMod::hpt_bell;
+                        if ( monumentID == HetuwMod::OBJID_EndTower2 ||
+                             monumentID == HetuwMod::OBJID_EndTower3 ||
+                             monumentID == HetuwMod::OBJID_EndTower4 ) {
+                                hpt = HetuwMod::hpt_apoc;
+                            }
+                        HetuwMod::addHomeLocation( posX, posY, hpt );
                         isAncientHomePosHell = false;
                         
                         // play sound in distance

--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -19891,7 +19891,7 @@ void LivingLifePage::step() {
                                 
                                 existing->currentSpeech = 
                                     stringDuplicate( &( firstSpace[1] ) );
-                                HetuwMod::decodeDigits( existing->currentSpeech, existing->currentSpeech );  // YumLife mod
+                                HetuwMod::decodeDigits( existing->currentSpeech );  // YumLife mod
                                 
 
                                 double curTime = game_getCurrentTime();

--- a/gameSource/RebirthChoicePage.cpp
+++ b/gameSource/RebirthChoicePage.cpp
@@ -161,13 +161,8 @@ void RebirthChoicePage::makeActive( char inFresh ) {
         mReviewButton.setLabelText( translate( "postReviewButton" ) );
         }    
 
-    if( SettingsManager::getIntSetting( "useSteamUpdate", 0 ) ) {
-        // no review button on Steam
-        mReviewButton.setVisible( false );
-        }
-    else {
-        mReviewButton.setVisible( true );
-        }
+    // YumLife: always show review button
+    mReviewButton.setVisible( true );
 
 
     int tutorialDone = SettingsManager::getIntSetting( "tutorialDone", 0 );

--- a/gameSource/hetuwmod.cpp
+++ b/gameSource/hetuwmod.cpp
@@ -1741,7 +1741,7 @@ void HetuwMod::encodeDigits(const char *plain, char *encoded) {
 	int j = 0;
 	size_t len = strlen(plain);
 	for (size_t i=0; i<len; i++) {
-		if (isdigit(plain[i])) {
+		if ('0' <= plain[i] && plain[i] <= '9') {
 			if (!questionMark) {
 				questionMark = true;
 				encoded[j++] = '?';
@@ -1755,13 +1755,13 @@ void HetuwMod::encodeDigits(const char *plain, char *encoded) {
 	encoded[j] = '\0';
 }
 
-void HetuwMod::decodeDigits(const char *encoded, char *plain) {
+void HetuwMod::decodeDigits(const char *msg) {
 	bool questionMark = false;
 	bool overwritten = false;
 	int j = 0;
-	size_t len = strlen(encoded);
+	size_t len = strlen(msg);
 	for (size_t i=0; i<len; i++) {
-		char c = encoded[i];
+		char c = msg[i];
 		if (questionMark) {
 			int n = c - 'A';
 			if (n >= 0 && n < 10) {
@@ -1769,19 +1769,19 @@ void HetuwMod::decodeDigits(const char *encoded, char *plain) {
 					overwritten = true;
 					j--;
 				}
-				plain[j++] = n + '0';
+				msg[j++] = n + '0';
 				continue;
 			} else {
 				questionMark = false;
 				overwritten = false;
 			}
 		}
-		plain[j++] = c;
+		msg[j++] = c;
 		if (c == '?') {
 			questionMark = true;
 		}
 	}
-	plain[j] = '\0';
+	msg[j] = '\0';
 }
 
 void HetuwMod::teachLanguage() {

--- a/gameSource/hetuwmod.h
+++ b/gameSource/hetuwmod.h
@@ -604,7 +604,7 @@ public:
 
 	static void Say(const char *text);
 	static void encodeDigits(const char *plain, char *encoded);
-	static void decodeDigits(const char *encoded, char *plain);
+	static void decodeDigits(const char *msg);
 	static void causeDisconnect();
 
 	static float colorRainbowFast[3];

--- a/gameSource/hetuwmod.h
+++ b/gameSource/hetuwmod.h
@@ -279,8 +279,9 @@ public:
 	static constexpr int OBJID_ClayPlate = 236;
 	static constexpr int OBJID_HotAdobeOven = 250;
 
-	static constexpr int OBJID_BellTowerSound = 839;
-	static constexpr int OBJID_EndTowerSound = 2481;
+	static constexpr int OBJID_EndTower2 = 2486;
+	static constexpr int OBJID_EndTower3 = 2484;
+	static constexpr int OBJID_EndTower4 = 2481;
 
 	static constexpr int OBJID_TarrMonument = 3112;
 

--- a/gameSource/hetuwmod.h
+++ b/gameSource/hetuwmod.h
@@ -603,6 +603,8 @@ public:
 	static void SetFixCamera(bool b);
 
 	static void Say(const char *text);
+	static void encodeDigits(const char *plain, char *encoded);
+	static void decodeDigits(const char *encoded, char *plain);
 	static void causeDisconnect();
 
 	static float colorRainbowFast[3];

--- a/gameSource/phex.cpp
+++ b/gameSource/phex.cpp
@@ -1175,9 +1175,8 @@ bool Phex::onMouseDown(float x, float y) {
 	if (!HetuwMod::phexIsEnabled) return false;
 	HetuwMod::pointFromMapToPercentCoords(x, y);
 	if (!HetuwMod::pointIsInsideRec(recBckgr, x, y)) {
-		onUpdateFocus(false);
-		return false;
-	}
+        return false;
+    }
 	for(unsigned k=0; k<buttons.size(); k++) {
 		if (buttons[k]->onMouseDown(x, y)) return true;
 	}

--- a/gameSource/phex.cpp
+++ b/gameSource/phex.cpp
@@ -102,9 +102,6 @@ int Phex::lastPositionSentY = -9999;
 
 constexpr char Phex::hexDigits[];
 
-int Phex::upperCaseCount = 0;
-bool Phex::allToLowerCase = false;
-
 extern doublePair lastScreenViewCenter;
 extern char *userEmail;
 extern int versionNumber;
@@ -905,18 +902,6 @@ void Phex::sendInputStr() {
 }
 
 bool Phex::addToInputStr(unsigned char c) {
-	if (!allToLowerCase) { // force lowercase after a user typed too many chars in upper
-		if (isupper(c)) {
-			upperCaseCount++;
-			if (upperCaseCount > 3) {
-				allToLowerCase = true;
-				c = tolower(c);
-			}
-		} else upperCaseCount = 0;
-	} else {
-		c = tolower(c);
-	}
-
 	if (c == 13) { // enter
 		if (tcp.status != TCPConnection::ONLINE) return true;
 		sendInputStr();

--- a/gameSource/phex.h
+++ b/gameSource/phex.h
@@ -412,9 +412,6 @@ private:
 	static int lastPositionSentY;
 	static void sendPosition();
 
-	static int upperCaseCount;
-	static bool allToLowerCase;
-
 };
 
 #endif


### PR DESCRIPTION
- Numbers will be encoded and decoded in speech using ?A = 0, ?B = 1, ... , ?J = 9
  - E.g. 123 is represented as ?BCD
- Phex won't automatically minimize when moving to allow chatting on the road
- The review button is now always visible
- Phex no longer forces all characters lowercase after multiple capitals are typed in a row
- The apocalypse bell should produce coordinates using the "apoc" tag instead of the "bell" tag for all stages