### PR TITLE
Fixes

### DIFF
--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -24599,7 +24599,9 @@ static void freeSavedPath() {
 
 void LivingLifePage::pointerDown( float inX, float inY ) {
 	
-	if (minitech::livingLifePageMouseDown( inX, inY )) return;
+    if (!mForceGroundClick && 
+        !isLastMouseButtonRight() &&
+        minitech::livingLifePageMouseDown( inX, inY )) return;
 	
 	if (!mForceGroundClick && HetuwMod::livingLifePageMouseDown( inX, inY ))
 		return;

--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -22048,6 +22048,16 @@ void LivingLifePage::step() {
             
             setViewCenterPosition( lastScreenViewCenter.x, 
                                    lastScreenViewCenter.y );
+								   
+            getLastMouseScreenPos( &lastScreenMouseX, &lastScreenMouseY );
+            screenToWorld( lastScreenMouseX,
+                            lastScreenMouseY,
+                            &lastMouseX,
+                            &lastMouseY );
+						   
+            // camera moved, simulate a pointer move to the last known position
+            // to check again what the pointer is hitting
+            pointerMove( lastMouseX, lastMouseY );
             
             }
 


### PR DESCRIPTION
This fixes 2 bugs.

1. If you hover over an object (cursor tips is displayed), and then move your camera without moving the cursor (say by holding D key), the cursor tips will not update, it stays on the tile where the cursor was.

2. If you freeze your camera and move with WASD so that minitech is drawn on top of the next tile the character is going (see picture below), minitech will maximize itself. Same can be triggered with auto-run instead of WASD.

![01](https://github.com/selb/YumLife/assets/67486979/2bfd7614-e913-4535-bddf-0e7b415f83b5)