### PR TITLE
Revert "Drop-in replacement of minorGems thread & mutex implementations"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.13)
 
 project(YumLife)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 14)
 
 set(MINORGEMS_COMMON_SOURCE_FILES
     minorGems/graphics/openGL/ScreenGL_SDL.cpp
@@ -50,6 +50,8 @@ if (WIN32)
         minorGems/io/win32/TypeIOWin32.cpp
         minorGems/io/file/win32/PathWin32.cpp
         minorGems/system/win32/TimeWin32.cpp
+        minorGems/system/win32/ThreadWin32.cpp
+        minorGems/system/win32/MutexLockWin32.cpp
         minorGems/system/win32/BinarySemaphoreWin32.cpp
         minorGems/network/win32/SocketWin32.cpp
         minorGems/network/win32/HostAddressWin32.cpp
@@ -61,6 +63,8 @@ else()
     set(MINORGEMS_PLATFORM_SOURCE_FILES
         minorGems/io/linux/TypeIOLinux.cpp
         minorGems/io/file/linux/PathLinux.cpp
+        minorGems/system/linux/ThreadLinux.cpp
+        minorGems/system/linux/MutexLockLinux.cpp
         minorGems/system/linux/BinarySemaphoreLinux.cpp
         minorGems/network/linux/SocketLinux.cpp
         minorGems/network/linux/HostAddressLinux.cpp

--- a/minorGems/system/MutexLock.h
+++ b/minorGems/system/MutexLock.h
@@ -13,12 +13,59 @@
  *
  * 2011-March-9    Jason Rohrer
  * Removed Fortify inclusion.
- *
- * 2024-June-03 Marek Schwann
- * std::mutex better
  */
 
-#pragma once
-#include <mutex>
 
-using MutexLock = std::mutex;
+
+#ifndef MUTEX_LOCK_CLASS_INCLUDED
+#define MUTEX_LOCK_CLASS_INCLUDED
+
+
+
+
+
+
+/**
+ * Mutex lock class.
+ *
+ * Note:  Implementation for the functions defined here is provided
+ *   separately for each platform (in the mac/ linux/ and win32/ 
+ *   subdirectories).
+ *
+ * @author Jason Rohrer
+ */
+class MutexLock {
+
+	public:
+		
+		/**
+		 * Constructs a mutex lock;
+		 */
+		MutexLock();
+		
+		~MutexLock();
+		
+		
+		/**
+		 * Locks the mutex.  Blocks until mutex available if it's
+		 * already locked by another thread.
+		 */
+		void lock();
+		
+		/**
+		 * Unlocks the mutex.
+		 */
+		void unlock();
+
+
+	private:
+	
+		/**
+		 * Used by platform-specific implementations.
+		 */		
+		void *mNativeObjectPointer;
+
+	};
+
+
+#endif

--- a/minorGems/system/Thread.h
+++ b/minorGems/system/Thread.h
@@ -1,40 +1,136 @@
-#pragma once
-#include <atomic>
-#include <chrono>
-#include <thread>
+/*
+ * Modification History
+ *
+ * 2000-December-13		Jason Rohrer
+ * Created.
+ *
+ * 2001-March-4		Jason Rohrer
+ * Made sleep() static so it can be called by non-Thread classes.
+ *
+ * 2001-May-12   Jason Rohrer
+ * Added comments about joining before destroying.
+ *
+ * 2002-March-29    Jason Rohrer
+ * Added Fortify inclusion.
+ *
+ * 2002-August-5    Jason Rohrer
+ * Made destructor virtual.
+ *
+ * 2004-March-31   Jason Rohrer
+ * Added support for detatched mode.
+ *
+ * 2005-January-9   Jason Rohrer
+ * Made sleep function virtual to allow overrides.
+ *
+ * 2005-January-22   Jason Rohrer
+ * Added a static sleep function.
+ *
+ * 2011-March-9    Jason Rohrer
+ * Removed Fortify inclusion.
+ */
 
+#include "minorGems/common.h"
+
+
+
+#ifndef THREAD_CLASS_INCLUDED
+#define THREAD_CLASS_INCLUDED
+
+
+
+
+
+
+/**
+ * Base class to be subclassed by all threads.
+ *
+ * Note:  Implementation for the functions defined here is provided
+ *   separately for each platform (in the mac/ linux/ and win32/ 
+ *   subdirectories).
+ *
+ * @author Jason Rohrer
+ */ 
 class Thread {
-public:
-  Thread() = default;
-  virtual ~Thread() = default;
-  void start(bool isDetach = false) {
-    t_ = std::thread(Thread::worker, this);
-    isDetatched_.store(isDetach, std::memory_order_release);
-    if (isDetach)
-      t_.detach();
-  }
-  virtual void run() = 0;
-  void join() { t_.join(); }
-  static void staticSleep(unsigned long inTimeInMilliseconds) {
-    std::this_thread::sleep_for(
-        std::chrono::milliseconds(inTimeInMilliseconds));
-  }
-  virtual void sleep(unsigned long inTimeInMilliseconds) {
-    staticSleep(inTimeInMilliseconds);
-  }
-  static void worker(Thread *t) {
-    t->run();
-    // This was like this in the original code - does it imply that this class
-    // gets created and then never deallocated, hoping that the thread on finish
-    // will clean up? No idea.
-    if (t->isDetatched()) {
-      delete t;
-    }
-  }
-  // This might be a tick-off, but generally faster.
-  bool isDetatched() { return isDetatched_.load(std::memory_order_relaxed); }
 
-private:
-  std::thread t_;
-  std::atomic_bool isDetatched_;
-};
+	public:
+	
+		Thread();		
+		virtual ~Thread();
+	
+		
+		/**
+		 * Starts this Thread.
+		 *
+		 * Note that after starting a non-detached thread, it _must_ be
+         * joined before being destroyed to avoid memory leaks.
+         *
+         * Threads running in detatched mode handle their own destruction
+         * as they terminate and do not need to be joined at all.
+         *
+         * @param inDetach true if this thread should run in detatched mode,
+         *   or false to run in non-detached mode.  Defaults to false.    
+		 */
+		void start( char inDetach = false );
+		
+		
+		/**
+		 * To be overriden by subclasses.
+		 * This method will be run by the Thread after start() has been called.
+		 */
+		virtual void run() = 0;
+		
+		
+		/**
+		 * Blocks until this thread finishes executing its run() method.
+		 *
+		 * Must be called before destroying this thread, if this thread
+		 * has been started.
+		 */
+		void join();
+
+		
+		/**
+		 * Puts the current thread to sleep for a specified amount of time.
+		 *
+		 * Note that given a thread instance threadA, calling threadA.sleep()
+		 * will put the calling thread to sleep.
+		 *
+		 * @param inTimeInMilliseconds the number of milliseconds to sleep.
+		 */
+		virtual void sleep( unsigned long inTimeInMilliseconds ) {
+            staticSleep( inTimeInMilliseconds );
+            }
+
+
+        
+        /**
+         * Same as sleep, but can be called without constructing a thread.
+         */
+        static void staticSleep( unsigned long inTimeInMilliseconds );
+
+        
+
+        /**
+         * Gets whether this thread is detached.
+         *
+         * @return true if this thread is detached.
+         */
+        char isDetatched() {
+            return mIsDetached;
+            }
+
+
+        
+	private:
+		
+		/**
+		 * Used by platform-specific implementations.
+		 */		
+		void *mNativeObjectPointer;
+
+
+        char mIsDetached;
+		
+	};		
+	
+#endif

--- a/minorGems/system/linux/MutexLockLinux.cpp
+++ b/minorGems/system/linux/MutexLockLinux.cpp
@@ -1,0 +1,76 @@
+/*
+ * Modification History
+ *
+ * 2000-December-13		Jason Rohrer
+ * Created.
+ *
+ * 2002-October-18    Jason Rohrer
+ * Moved common include out of header and into platform-specific cpp files,
+ * since MemoryTrack uses a mutex lock.
+ * Changed to use malloc instead of new internally to work with debugMemory.
+ * Made use of mNativeObjectPointer a bit cleaner.
+ */
+
+#include "minorGems/common.h"
+
+
+
+#include <minorGems/system/MutexLock.h>
+#include <pthread.h>
+#include <stdlib.h>
+
+/**
+ * Linux-specific implementation of the MutexLock class member functions.
+ *
+ * May also be compatible with other POSIX-like systems.
+ *
+ * To compile:
+ * g++ -lpthread
+ */
+
+
+MutexLock::MutexLock() {
+	// allocate a mutex structure on the heap
+	mNativeObjectPointer = malloc( sizeof( pthread_mutex_t ) );
+	
+	// get a pointer to the mutex
+	pthread_mutex_t *mutexPointer = 
+		(pthread_mutex_t *)mNativeObjectPointer;
+	
+	// init the mutex
+	pthread_mutex_init( mutexPointer, NULL );
+	}
+
+
+
+MutexLock::~MutexLock() {
+	// get a pointer to the mutex
+	pthread_mutex_t *mutexPointer = 
+		(pthread_mutex_t *)mNativeObjectPointer;
+	
+	// destroy the mutex	
+	pthread_mutex_destroy( mutexPointer );
+	
+	// de-allocate the mutex structure from the heap
+	free( mNativeObjectPointer );
+	}
+
+
+
+void MutexLock::lock() {
+	// get a pointer to the mutex
+	pthread_mutex_t *mutexPointer = 
+		(pthread_mutex_t *)mNativeObjectPointer;
+	
+	pthread_mutex_lock( mutexPointer );
+	}
+
+
+
+void MutexLock::unlock() {
+	// get a pointer to the mutex
+	pthread_mutex_t *mutexPointer = 
+		(pthread_mutex_t *)mNativeObjectPointer;
+	
+	pthread_mutex_unlock( mutexPointer );
+	}

--- a/minorGems/system/linux/ThreadLinux.cpp
+++ b/minorGems/system/linux/ThreadLinux.cpp
@@ -1,0 +1,246 @@
+/*
+ * Modification History
+ *
+ * 2000-December-13		Jason Rohrer
+ * Created.
+ *
+ * 2001-January-11		Jason Rohrer
+ * Added missing sleep() implementation. 
+ *
+ * 2002-March-27   Jason Rohrer
+ * Added support for gprof-friendly thread wrappers.
+ * Fixed a compile bug when gprof threads disabled.
+ *
+ * 2002-August-5   Jason Rohrer
+ * Removed an unused variable.
+ *
+ * 2003-February-3   Jason Rohrer
+ * Fixed sleep to be thread safe (signals were interrupting thread sleeps).
+ *
+ * 2004-March-31   Jason Rohrer
+ * Added support for detatched mode.
+ *
+ * 2005-January-22   Jason Rohrer
+ * Added a static sleep function.
+ */
+
+
+
+#include <minorGems/system/Thread.h>
+#include <pthread.h>
+
+#include <unistd.h>
+#include <stdio.h>
+
+
+
+/**
+ * Linux-specific implementation of the Thread class member functions.
+ *
+ * May also be compatible with other POSIX-like systems.
+ *
+ * To compile:
+ * g++ -lpthread
+ * If thread profiling is desired for gprof on linux, compile
+ * with -DUSE_GPROF_THREADS (otherwise, only main thread is profiled).
+ */
+
+
+
+#ifdef USE_GPROF_THREADS
+// prototype
+int gprof_pthread_create( pthread_t * thread, pthread_attr_t * attr,
+                          void * (*start_routine)(void *), void * arg );
+#endif
+
+
+
+// prototype
+/**
+ * A wrapper for the run method, since pthreads won't take
+ * a class's member function.  Takes a pointer to the Thread to run,
+ * cast as a void*;
+ */
+void *linuxThreadFunction( void * );
+
+
+
+Thread::Thread() {
+	// allocate a pthread structure on the heap
+	mNativeObjectPointer = (void *)( new pthread_t[1] );
+	}
+
+
+
+Thread::~Thread() {
+	// de-allocate the pthread structure from the heap
+	pthread_t *threadPointer = (pthread_t *)mNativeObjectPointer;
+	delete [] threadPointer;
+	}
+
+
+
+void Thread::start( char inDetach ) {
+
+    mIsDetached = inDetach;
+    
+	// get a pointer to the pthread
+	pthread_t *threadPointer = (pthread_t *)mNativeObjectPointer;
+	
+	// create the pthread, which also sets it running
+#ifdef USE_GPROF_THREADS
+    gprof_pthread_create( &( threadPointer[0] ), NULL, 
+		linuxThreadFunction, (void*)this );
+#else
+    pthread_create( &( threadPointer[0] ), NULL, 
+		linuxThreadFunction, (void*)this );
+#endif
+
+    if( mIsDetached ) {
+        pthread_detach( threadPointer[0] );
+        }
+	}
+
+
+
+void Thread::join() {
+	void *joinStat;
+	
+	pthread_t *threadPointer = (pthread_t *)mNativeObjectPointer;
+	
+	pthread_join( threadPointer[0], &joinStat );
+	}
+
+
+
+void Thread::staticSleep( unsigned long inTimeInMilliseconds ) {
+
+    unsigned long seconds = inTimeInMilliseconds / 1000;
+    unsigned long milliseconds = inTimeInMilliseconds % 1000;
+    
+    struct timespec remainingSleepTimeStruct;
+    remainingSleepTimeStruct.tv_sec = seconds;
+    remainingSleepTimeStruct.tv_nsec = milliseconds * 1000000;
+
+    struct timespec timeToSleepStruct;
+    
+    // sleep repeatedly, ignoring signals, untill we use up all of the time
+    int sleepReturn = -1;
+    while( sleepReturn == -1 ) {
+
+        timeToSleepStruct.tv_sec = remainingSleepTimeStruct.tv_sec;
+        timeToSleepStruct.tv_nsec = remainingSleepTimeStruct.tv_nsec;
+        
+        sleepReturn =
+            nanosleep( &timeToSleepStruct, &remainingSleepTimeStruct );
+        }    
+	}
+
+
+
+// takes a pointer to a Thread object as the data value
+void *linuxThreadFunction( void *inPtrToThread ) {
+	Thread *threadToRun = (Thread *)inPtrToThread;
+	threadToRun->run();
+
+    if( threadToRun->isDetatched() ) {
+        // thread detached, so we must destroy it
+        delete threadToRun;
+        }
+    
+	return inPtrToThread;
+	}
+
+
+
+
+
+#ifdef USE_GPROF_THREADS
+
+
+
+// found at http://sam.zoy.org/doc/programming/gprof.html
+#include <sys/time.h>
+/*
+ * pthread_create wrapper for gprof compatibility
+ *
+ * needed headers: <pthread.h>
+ *                 <sys/time.h>
+ */
+typedef struct wrapper_s {
+        void * (*start_routine)(void *);
+        void * arg;
+        pthread_mutex_t lock;
+        pthread_cond_t  wait;
+        struct itimerval itimer;
+    } wrapper_t;
+
+
+
+static void * wrapper_routine(void *);
+
+
+
+/**
+ * Same prototype as pthread_create; use some #define magic to
+ * transparently replace it in other files
+ */
+int gprof_pthread_create( pthread_t * thread, pthread_attr_t * attr,
+                          void * (*start_routine)(void *), void * arg ) {
+
+    wrapper_t wrapper_data;
+    int i_return;
+
+    /* Initialize the wrapper structure */
+    wrapper_data.start_routine = start_routine;
+    wrapper_data.arg = arg;
+    getitimer(ITIMER_PROF, &wrapper_data.itimer);
+    pthread_cond_init(&wrapper_data.wait, NULL);
+    pthread_mutex_init(&wrapper_data.lock, NULL);
+    pthread_mutex_lock(&wrapper_data.lock);
+
+    /* The real pthread_create call */
+    i_return = pthread_create(thread, attr, &wrapper_routine,
+                                            &wrapper_data);
+
+    /* If the thread was successfully spawned, wait for the data
+     * to be released */
+    if( i_return == 0 ) {
+        pthread_cond_wait(&wrapper_data.wait, &wrapper_data.lock);
+        }
+
+    pthread_mutex_unlock(&wrapper_data.lock);
+    pthread_mutex_destroy(&wrapper_data.lock);
+    pthread_cond_destroy(&wrapper_data.wait);
+    return i_return;
+    }
+
+
+
+/**
+ * The wrapper function in charge for setting the itimer value
+ */
+static void * wrapper_routine( void * data ) {
+
+    /* Put user data in thread-local variables */
+    void * (*start_routine)(void *) = ((wrapper_t*)data)->start_routine;
+    void * arg = ((wrapper_t*)data)->arg;
+
+    /* Set the profile timer value */
+    setitimer(ITIMER_PROF, &((wrapper_t*)data)->itimer, NULL);
+
+    /* Tell the calling thread that we don't need its data anymore */
+    pthread_mutex_lock(&((wrapper_t*)data)->lock);
+    pthread_cond_signal(&((wrapper_t*)data)->wait);
+    pthread_mutex_unlock(&((wrapper_t*)data)->lock);
+
+    /* Call the real function */
+    return start_routine(arg);
+    }
+
+
+
+#endif
+
+
+

--- a/minorGems/system/win32/MutexLockWin32.cpp
+++ b/minorGems/system/win32/MutexLockWin32.cpp
@@ -1,0 +1,81 @@
+/*
+ * Modification History
+ *
+ * 2001-January-27		Jason Rohrer
+ * Created.
+ *
+ * 2001-March-4		Jason Rohrer
+ * Replaced include of <winbase.h> and <windef.h> with <windows.h> 
+ * to fix compile bugs encountered with newer windows compilers.   
+ *
+ * 2002-October-18    Jason Rohrer
+ * Moved common include out of header and into platform-specific cpp files,
+ * since MemoryTrack uses a mutex lock.
+ *
+ * 2002-October-19    Jason Rohrer
+ * Changed to use malloc instead of new internally to work with debugMemory.
+ * Made use of mNativeObjectPointer a bit cleaner.
+ * Fixed a few bugs with new use of mNativeObjectPointer.
+ */
+
+#include "minorGems/common.h"
+
+
+
+#include "minorGems/system/MutexLock.h"
+
+#include <windows.h>
+#include <stdlib.h>
+
+
+
+/**
+ * Win32-specific implementation of the MutexLock class member functions.
+ */
+
+
+MutexLock::MutexLock() {
+	// allocate a handle on the heap
+	mNativeObjectPointer = malloc( sizeof( HANDLE ) );
+	
+	// retrieve handle from the heap
+	HANDLE *mutexPointer = (HANDLE *)mNativeObjectPointer;
+	
+	// create the mutex
+	*mutexPointer = CreateMutex(
+		(LPSECURITY_ATTRIBUTES) NULL,	//  no attributes
+  		(BOOL) false,			// not initially locked
+  		(LPCTSTR) NULL );		// no name
+	}
+
+
+
+MutexLock::~MutexLock() {
+	// retrieve handle from the heap
+	HANDLE *mutexPointer = (HANDLE *)mNativeObjectPointer;
+	  
+	// destroy the mutex	
+	CloseHandle( *mutexPointer );
+	
+	// de-allocate the mutex structure from the heap
+	free( mutexPointer );
+	}
+
+
+
+void MutexLock::lock() {
+	// retrieve handle from the heap
+	HANDLE *mutexPointer = (HANDLE *)mNativeObjectPointer;
+	
+	WaitForSingleObject( *mutexPointer, INFINITE );
+	}
+
+
+
+void MutexLock::unlock() {
+	// retrieve handle from the heap
+	HANDLE *mutexPointer = (HANDLE *)mNativeObjectPointer;
+	
+	ReleaseMutex( *mutexPointer );
+	}
+

--- a/minorGems/system/win32/ThreadWin32.cpp
+++ b/minorGems/system/win32/ThreadWin32.cpp
@@ -1,0 +1,108 @@
+/*
+ * Modification History
+ *
+ * 2001-January-27		Jason Rohrer
+ * Created.
+ *
+ * 2001-March-4		Jason Rohrer
+ * Replaced include of <winbase.h> and <windef.h> with <windows.h> 
+ * to fix compile bugs encountered with newer windows compilers.   
+ *
+ * 2004-March-31   Jason Rohrer
+ * Added missing call to CloseHandle in destructor.
+ * Added support for detatched mode.
+ *
+ * 2004-April-1   Jason Rohrer
+ * Fixed a bug in CloseHandle call pointed out by Mycroftxxx.
+ *
+ * 2005-January-22   Jason Rohrer
+ * Added a static sleep function.
+ */
+ 
+#include "minorGems/system/Thread.h"
+
+#include <windows.h>
+
+
+/**
+ * Win32-specific implementation of the Thread class member functions.
+ *
+ */
+
+
+// prototype
+/**
+ * A wrapper for the run method, since windows thread (perhaps) won't take
+ * a class's member function.  Takes a pointer to the Thread to run,
+ * cast as a void*;
+ */
+DWORD WINAPI win32ThreadFunction( void * );
+
+
+
+Thread::Thread() {
+	// allocate a handle on the heap
+	mNativeObjectPointer = (void *)( new HANDLE[1] );
+	}
+
+
+
+Thread::~Thread() {
+    // get a pointer to the allocated handle
+	HANDLE *threadPointer = (HANDLE *)mNativeObjectPointer;
+
+    // close the handle to ensure that the thread resources are freed
+    CloseHandle( threadPointer[0] );
+    
+    // de-allocate the thread handle from the heap
+	delete [] threadPointer;
+	}
+
+
+
+void Thread::start( char inDetach ) {
+
+    mIsDetached = inDetach;
+    
+	// get a pointer to the allocated handle
+	HANDLE *threadPointer = (HANDLE *)mNativeObjectPointer;
+	
+	DWORD threadID;
+	
+	threadPointer[0] = CreateThread( 
+						(LPSECURITY_ATTRIBUTES)NULL,	// no attributes 
+						(DWORD)0, 		// default stack size
+						win32ThreadFunction,	// function
+						(LPVOID)this,			// function arg
+						(DWORD)0,		// no creation flags (start thread immediately)
+						&threadID );					 
+	}    
+
+
+
+void Thread::join() {
+	
+	HANDLE *threadPointer = (HANDLE *)mNativeObjectPointer;
+	
+	WaitForSingleObject( threadPointer[0], INFINITE );
+	}
+
+
+void Thread::staticSleep( unsigned long inTimeInMilliseconds ) {
+	Sleep( inTimeInMilliseconds );
+	}
+
+
+// takes a pointer to a Thread object as the data value
+DWORD WINAPI win32ThreadFunction( void *inPtrToThread ) {
+	Thread *threadToRun = (Thread *)inPtrToThread;
+	threadToRun->run();
+
+    
+    if( threadToRun->isDetatched() ) {
+        // thread detached, so we must destroy it
+        delete threadToRun;
+        }
+
+	return 0;
+	}


### PR DESCRIPTION
Reverts selb/YumLife#72 for now. MinGW does not provide an implementation without asking for winpthreads, and we're not ready to distribute that. Will re-merge once we are producing a .zip with dependencies, which we will have to do anyway once we start bringing in OpenSSL and other libraries.